### PR TITLE
Remove Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ notifications:
 
 matrix:
  include:
-   - python: 3.5
    - python: 3.6
    - python: 3.7
    - python: 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37-lint, py35, py36, py37, py38
+envlist = py37-lint, py36, py37, py38
 
 [testenv:py37-lint]
 basepython = python3.7


### PR DESCRIPTION
[Python 3.5 is now EoL](https://www.python.org/dev/peps/pep-0478/). This PR removes it from CI.