### PR TITLE
Modify bumpversion for pep440 normalized versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,11 +2,15 @@
 current_version = 0.0.31
 commit = True
 message = Update version {current_version} -> {new_version}
-parse = ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:[\-\.]?(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
-serialize = 
-	{major}.{minor}.{patch}{prerelease}+{buildmetadata}
-	{major}.{minor}.{patch}{prerelease}
-	{major}.{minor}.{patch}+{buildmetadata}
+parse = ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?P<prerelease>[a|b|rc](?:0|[1-9]\d*))?(?P<devrelease>(?:\.dev)(?:0|[1-9]\d*))?(?P<buildmetadata>\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$
+serialize =
+	{major}.{minor}.{patch}{prerelease}{devrelease}{buildmetadata}
+  {major}.{minor}.{patch}{prerelease}{devrelease}
+	{major}.{minor}.{patch}{prerelease}{buildmetadata}
+  {major}.{minor}.{patch}{prerelease}
+	{major}.{minor}.{patch}{devrelease}{buildmetadata}
+	{major}.{minor}.{patch}{devrelease}
+	{major}.{minor}.{patch}{buildmetadata}
 	{major}.{minor}.{patch}
 
 [bumpversion:file:ibmcloudant/version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,9 +5,9 @@ message = Update version {current_version} -> {new_version}
 parse = ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?P<prerelease>[a|b|rc](?:0|[1-9]\d*))?(?P<devrelease>(?:\.dev)(?:0|[1-9]\d*))?(?P<buildmetadata>\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$
 serialize =
 	{major}.{minor}.{patch}{prerelease}{devrelease}{buildmetadata}
-  {major}.{minor}.{patch}{prerelease}{devrelease}
+	{major}.{minor}.{patch}{prerelease}{devrelease}
 	{major}.{minor}.{patch}{prerelease}{buildmetadata}
-  {major}.{minor}.{patch}{prerelease}
+	{major}.{minor}.{patch}{prerelease}
 	{major}.{minor}.{patch}{devrelease}{buildmetadata}
 	{major}.{minor}.{patch}{devrelease}
 	{major}.{minor}.{patch}{buildmetadata}


### PR DESCRIPTION
## PR summary

Update bumpversion to serialize a PEP440 normalized version

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [ ] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Currently publishing produces a warning:
```
/usr/local/lib/python3.6/dist-packages/setuptools/dist.py:461: UserWarning: Normalizing '0.0.32dev1613061892598+14ebe48.6' to '0.0.32.dev1613061892598+14ebe48.6'
```

Although we produce a PEP440 normalized version in our pipeline we have a slight configuration error in `.bumpversion.cfg` that serializes it in form that is PEP440 tooling compliant, but requires normalization - this produces the warning above. Specifically we serialize it without the `.` before the dev (which is the pattern only for `a`, `b` and `rc` pre-releases not developer builds).

## What is the new behavior?

The new behaviour is to separately group the `prerelease` `devrelease` and `buildmetadata` parts of the version including their correct separators and provide all the combinations of those groups as serialize options.
The `prerelease` and `devrelease` parts have also been updated to follow PEP440 numbering instead of full semver.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

