### PR TITLE
Add 2.5 minutes read timeout as a default timeout value

### DIFF
--- a/ibmcloudant/cloudant_base_service.py
+++ b/ibmcloudant/cloudant_base_service.py
@@ -17,9 +17,10 @@
 Module to patch sdk core base service for session authentication
 """
 from collections import namedtuple
+from requests.cookies import RequestsCookieJar
 from typing import Dict, Optional, Union, Tuple, List
 from urllib.parse import urlsplit, unquote
-from requests.cookies import RequestsCookieJar
+from urllib3 import Timeout
 
 from ibm_cloud_sdk_core.authenticators import Authenticator
 from .common import get_sdk_headers
@@ -65,6 +66,9 @@ old_init = CloudantV1.__init__
 
 def new_init(self, authenticator: Authenticator = None):
     old_init(self, authenticator)
+    # Overwrite default read timeout to 2.5 minutes
+    if not ('timeout' in self.http_config):
+        self.set_http_config({'timeout':Timeout(connect=60, read=150)})
     # Custom actions for CouchDbSessionAuthenticator
     if isinstance(authenticator, CouchDbSessionAuthenticator):
         # Replacing BaseService's http.cookiejar.CookieJar as RequestsCookieJar supports update(CookieJar)

--- a/ibmcloudant/cloudant_base_service.py
+++ b/ibmcloudant/cloudant_base_service.py
@@ -17,12 +17,12 @@
 Module to patch sdk core base service for session authentication
 """
 from collections import namedtuple
-from requests.cookies import RequestsCookieJar
 from typing import Dict, Optional, Union, Tuple, List
 from urllib.parse import urlsplit, unquote
-from urllib3 import Timeout
 
 from ibm_cloud_sdk_core.authenticators import Authenticator
+from requests.cookies import RequestsCookieJar
+
 from .common import get_sdk_headers
 from .cloudant_v1 import CloudantV1
 from .couchdb_session_authenticator import CouchDbSessionAuthenticator
@@ -72,7 +72,9 @@ def new_init(self, authenticator: Authenticator = None):
     old_init(self, authenticator)
     # Overwrite default read timeout to 2.5 minutes
     if not ('timeout' in self.http_config):
-        self.set_http_config({'timeout':Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT)})
+        new_http_config = self.http_config.copy()
+        new_http_config['timeout'] = (CONNECT_TIMEOUT, READ_TIMEOUT)
+        self.set_http_config(new_http_config)
     # Custom actions for CouchDbSessionAuthenticator
     if isinstance(authenticator, CouchDbSessionAuthenticator):
         # Replacing BaseService's http.cookiejar.CookieJar as RequestsCookieJar supports update(CookieJar)

--- a/ibmcloudant/cloudant_base_service.py
+++ b/ibmcloudant/cloudant_base_service.py
@@ -29,6 +29,10 @@ from .couchdb_session_authenticator import CouchDbSessionAuthenticator
 
 # pylint: disable=missing-docstring
 
+# Define timeout values
+CONNECT_TIMEOUT=60
+READ_TIMEOUT=150
+
 # Define validations
 class ValidationRule(namedtuple('ValidationRule', ['path_segment_index', 'error_parameter_name', 'operation_ids'])):
     __slots__ = ()
@@ -68,7 +72,7 @@ def new_init(self, authenticator: Authenticator = None):
     old_init(self, authenticator)
     # Overwrite default read timeout to 2.5 minutes
     if not ('timeout' in self.http_config):
-        self.set_http_config({'timeout':Timeout(connect=60, read=150)})
+        self.set_http_config({'timeout':Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT)})
     # Custom actions for CouchDbSessionAuthenticator
     if isinstance(authenticator, CouchDbSessionAuthenticator):
         # Replacing BaseService's http.cookiejar.CookieJar as RequestsCookieJar supports update(CookieJar)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ibm_cloud_sdk_core==3.11.3
-urllib3==1.26.6
 # dependencies of ibm_cloud_sdk_core:
 requests>=2.20,<3.0
 python_dateutil>=2.5.3,<3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ibm_cloud_sdk_core==3.11.3
+urllib3==1.26.6
 # dependencies of ibm_cloud_sdk_core:
 requests>=2.20,<3.0
 python_dateutil>=2.5.3,<3.0.0

--- a/test/integration/test_timeout.py
+++ b/test/integration/test_timeout.py
@@ -79,7 +79,7 @@ class TestTimeout(unittest.TestCase):
 # ** CloudantV1
 # *************
 # Check every authenticator type
-    def test_timeout_CloudantV1_NoAuth(self):
+    def test_timeout_cloudantv1_noauth(self):
         noAuth_auth = NoAuthAuthenticator()
         self.cloudant = CloudantV1(
             authenticator=noAuth_auth
@@ -99,7 +99,7 @@ class TestTimeout(unittest.TestCase):
             req_args=self._get_request_arguments(i)
             tc['assert_func'](req_args)
 
-    def test_timeout_CloudantV1_BasicAuth(self):
+    def test_timeout_cloudantv1_basicauth(self):
         basic_auth = BasicAuthenticator('name', 'psw')
         self.cloudant = CloudantV1(
             authenticator=basic_auth
@@ -120,7 +120,7 @@ class TestTimeout(unittest.TestCase):
             req_args=self._get_request_arguments(i)
             tc['assert_func'](req_args)
 
-    def test_timeout_CloudantV1_SessionAuth(self, timeout_mock_response=_timeout_mock_response):
+    def test_timeout_cloudantv1_sessionauth(self, timeout_mock_response=_timeout_mock_response):
         session_auth = CouchDbSessionAuthenticator('name', 'psw')
         self.cloudant = CloudantV1(
             authenticator=session_auth,
@@ -153,7 +153,7 @@ class TestTimeout(unittest.TestCase):
         # Set back requests.request
         requests.request = orig_request
 
-    def test_timeout_CloudantV1_IAMAuth(self, timeout_mock_response=_timeout_mock_response):
+    def test_timeout_cloudantv1_iamauth(self, timeout_mock_response=_timeout_mock_response):
         authenticator = IAMAuthenticator('apikey')
         self.cloudant = CloudantV1(
             authenticator=authenticator

--- a/test/integration/test_timeout.py
+++ b/test/integration/test_timeout.py
@@ -64,9 +64,9 @@ class TestTimeout(unittest.TestCase):
         requests.request.assert_called_once()
         return requests.request.mock_calls[0]
 
-    def _get_request_arguments(self, counter):
-        self.assertEqual(self.cloudant.http_client.request.call_count, counter + 1)
-        return self.cloudant.http_client.request.mock_calls[counter]
+    def _get_request_arguments(self, idx):
+        self.assertEqual(self.cloudant.http_client.request.call_count, idx + 1)
+        return self.cloudant.http_client.request.mock_calls[idx]
 
     def _assert_default_timeout_setting(self, call_args):
         _, _, kwargs = call_args
@@ -90,14 +90,14 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for idx, tc in enumerate(testcases):
+        for tc_num, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
             self.cloudant.get_server_information()
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(idx)
+            req_args = self._get_request_arguments(tc_num)
             tc['assert_func'](req_args)
 
     def test_timeout_cloudantv1_basicauth(self):
@@ -111,14 +111,14 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for idx, tc in enumerate(testcases):
+        for tc_num, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
             self.cloudant.get_server_information()
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(idx)
+            req_args = self._get_request_arguments(tc_num)
             tc['assert_func'](req_args)
 
     def test_timeout_cloudantv1_sessionauth(self, timeout_mock_response=MOCK_RESPONSE):
@@ -137,7 +137,7 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for idx, tc in enumerate(testcases):
+        for tc_num, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
@@ -148,7 +148,7 @@ class TestTimeout(unittest.TestCase):
             self._assert_default_timeout_setting(auth_args)
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(idx)
+            req_args = self._get_request_arguments(tc_num)
             tc['assert_func'](req_args)
 
         # Set back requests.request
@@ -171,7 +171,7 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for idx, tc in enumerate(testcases):
+        for tc_num, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
@@ -182,7 +182,7 @@ class TestTimeout(unittest.TestCase):
             self._assert_default_timeout_setting(auth_args)
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(idx)
+            req_args = self._get_request_arguments(tc_num)
             tc['assert_func'](req_args)
 
             # Set expire time to not authenticate again
@@ -203,12 +203,12 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for idx, tc in enumerate(testcases):
+        for tc_num, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
             self.cloudant.get_server_information()
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(idx)
+            req_args = self._get_request_arguments(tc_num)
             tc['assert_func'](req_args)

--- a/test/integration/test_timeout.py
+++ b/test/integration/test_timeout.py
@@ -90,14 +90,14 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for i, tc in enumerate(testcases):
+        for idx, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
             self.cloudant.get_server_information()
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(i)
+            req_args = self._get_request_arguments(idx)
             tc['assert_func'](req_args)
 
     def test_timeout_cloudantv1_basicauth(self):
@@ -111,14 +111,14 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for i, tc in enumerate(testcases):
+        for idx, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
             self.cloudant.get_server_information()
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(i)
+            req_args = self._get_request_arguments(idx)
             tc['assert_func'](req_args)
 
     def test_timeout_cloudantv1_sessionauth(self, timeout_mock_response=MOCK_RESPONSE):
@@ -137,7 +137,7 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for i, tc in enumerate(testcases):
+        for idx, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
@@ -148,7 +148,7 @@ class TestTimeout(unittest.TestCase):
             self._assert_default_timeout_setting(auth_args)
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(i)
+            req_args = self._get_request_arguments(idx)
             tc['assert_func'](req_args)
 
         # Set back requests.request
@@ -171,7 +171,7 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for i, tc in enumerate(testcases):
+        for idx, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
@@ -182,7 +182,7 @@ class TestTimeout(unittest.TestCase):
             self._assert_default_timeout_setting(auth_args)
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(i)
+            req_args = self._get_request_arguments(idx)
             tc['assert_func'](req_args)
 
             # Set expire time to not authenticate again
@@ -203,12 +203,12 @@ class TestTimeout(unittest.TestCase):
 
         testcases = self._defineTestCases()
 
-        for i, tc in enumerate(testcases):
+        for idx, tc in enumerate(testcases):
             tc['set_timeout'](CUSTOM_TIMEOUT_CONFIG)
 
             # Call the server
             self.cloudant.get_server_information()
 
             # Assert timeout is set in the server request
-            req_args = self._get_request_arguments(i)
+            req_args = self._get_request_arguments(idx)
             tc['assert_func'](req_args)

--- a/test/integration/test_timeout.py
+++ b/test/integration/test_timeout.py
@@ -1,4 +1,6 @@
-#  © Copyright IBM Corporation 2020.
+# coding: utf-8
+
+#  © Copyright IBM Corporation 2021.
 #  #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,17 +16,16 @@
 
 import time
 import unittest
-
-import requests
 from unittest.mock import Mock
+
+from ibm_cloud_sdk_core.authenticators import BasicAuthenticator, IAMAuthenticator, NoAuthAuthenticator
+import requests
 from requests import Response
-from urllib3 import Timeout
 
 from ibmcloudant.cloudant_v1 import CloudantV1
-from ibm_cloud_sdk_core.authenticators import BasicAuthenticator, IAMAuthenticator, NoAuthAuthenticator
 from ibmcloudant.couchdb_session_authenticator import CouchDbSessionAuthenticator
 
-DEFAULT_TIMEOUT = 150  # 2.5m (=150s)
+DEFAULT_TIMEOUT = (60, 150)  # 2.5m (=150s)
 CUSTOM_TIMEOUT = 10    # 10s
 CUSTOM_TIMEOUT_CONFIG = {'timeout': CUSTOM_TIMEOUT}
 
@@ -34,6 +35,8 @@ class Helpers():
     def get_current_time_plus_two_minute() -> int:
         return int(time.time()) + 120
 
+    # This mocked response has content that suitable for functionally test
+    # both authentication and service requests
     @staticmethod
     def get_mocked_response():
         mock_response = Response()
@@ -68,8 +71,8 @@ class Helpers():
     @staticmethod
     def assert_default_timeout_setting(tci, call_args):
         _, _, kwargs = call_args
-        tci.assertTrue(isinstance(kwargs['timeout'], Timeout))
-        tci.assertEqual(kwargs['timeout'].read_timeout, DEFAULT_TIMEOUT)
+        tci.assertTrue(isinstance(kwargs['timeout'], tuple))
+        tci.assertEqual(kwargs['timeout'], DEFAULT_TIMEOUT)
 
     @staticmethod
     def assert_custom_timeout_setting(tci, call_args):

--- a/test/integration/test_timeout.py
+++ b/test/integration/test_timeout.py
@@ -1,0 +1,212 @@
+#  © Copyright IBM Corporation 2020.
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#       http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import time
+import unittest
+
+import requests
+from unittest.mock import Mock
+from requests import Response
+from urllib3 import Timeout
+
+from ibmcloudant.cloudant_v1 import CloudantV1
+from ibm_cloud_sdk_core.authenticators import BasicAuthenticator, IAMAuthenticator, NoAuthAuthenticator
+from ibmcloudant.couchdb_session_authenticator import CouchDbSessionAuthenticator
+
+def create_mocked_response():
+    mock_response= Response()
+    mock_response.status_code=200
+    mock_response._content = '{"foo":"bar"}'.encode()
+    mock_response.cookies.set("AuthSession", "bar", expires=time.time()+120)
+    return mock_response
+
+class TestTimeout(unittest.TestCase):
+
+# ** Helpers
+# *************
+
+    _mock_response = create_mocked_response()
+
+    def _mock_out_authenticate_request(self, mock_response=_mock_response):
+        requests.request = Mock(return_value=mock_response)
+
+    def _mock_out_cloudant_request(self, _mock_response=_mock_response):
+        self.cloudant.http_client.request = Mock(return_value=_mock_response)
+
+    def _get_authenticate_arguments(self):
+        requests.request.assert_called_once()
+        first_call = requests.request.mock_calls[0]
+        return first_call
+
+    def _get_request_arguments(self):
+        self.cloudant.http_client.request.assert_called_once()
+        return self.cloudant.http_client.request.mock_calls[0]
+
+    def _assert_default_timeout_setting(self, call_args):
+        _, _, kwargs = call_args
+        self.assertTrue(isinstance(kwargs['timeout'], Timeout))
+        self.assertEqual(kwargs['timeout'].read_timeout, 150)
+
+    def _assert_custom_timeout_setting(self, call_args):
+        _, _, kwargs = call_args
+        self.assertEqual(kwargs['timeout'], 10)
+
+
+# ** CloudantV1
+# *************
+
+    def test_timeout_cloudantV1_NoAuth(self):
+        authenticator = NoAuthAuthenticator()
+        self.cloudant = CloudantV1(
+            authenticator=authenticator
+        )
+
+        self._mock_out_cloudant_request()
+
+        self.cloudant.get_server_information()
+
+        # Assert request arguments, here the timeout should be included
+        req_args=self._get_request_arguments()
+        self._assert_default_timeout_setting(req_args)
+
+    def test_timeout_cloudantV1_IAMAuth(self):
+        authenticator = IAMAuthenticator('apikey')
+        self.cloudant = CloudantV1(
+            authenticator=authenticator
+        )
+
+        # Mock out authentication
+        self._mock_out_authenticate_request()
+        self.cloudant.authenticator.token_manager._save_token_info=Mock()
+        self.cloudant.authenticator.token_manager.refresh_time = int(time.time()) + 60
+
+        # Mock out request response
+        self._mock_out_cloudant_request()
+
+        # Call the server
+        self.cloudant.get_server_information()
+
+        # Assert timeout is set to the authenticator
+        auth_args = self._get_authenticate_arguments()
+        self._assert_default_timeout_setting(auth_args)
+
+        # Assert timeout is set in the server request
+        req_args=self._get_request_arguments()
+        self._assert_default_timeout_setting(req_args)
+
+    # Check Basic - no authentication request case like `NoAuth
+    def test_timeout_cloudantV1_BasicAuth(self):
+        authenticator = BasicAuthenticator('name', 'psw')
+        self.cloudant = CloudantV1(
+            authenticator=authenticator
+        )
+
+        # Mock out request response
+        self._mock_out_cloudant_request()
+
+        # Call the server
+        self.cloudant.get_server_information()
+
+        # Assert timeout is set in the server request
+        req_args=self._get_request_arguments()
+        self._assert_default_timeout_setting(req_args)
+
+    def test_timeout_cloudantV1_SessionAuth(self):
+        authenticator = CouchDbSessionAuthenticator('name', 'psw')
+        self.cloudant = CloudantV1(
+            authenticator=authenticator,
+        )
+        self.cloudant.set_service_url("http://cloudant.example")
+
+        # Mock out authentication
+        self._mock_out_authenticate_request()
+
+        # Mock out request response
+        self._mock_out_cloudant_request()
+
+        # Call the server
+        self.cloudant.get_server_information()
+
+        # Assert timeout is set to the authenticator
+        auth_args = self._get_authenticate_arguments()
+        self._assert_default_timeout_setting(auth_args)
+
+        # Assert timeout is set in the server request
+        req_args=self._get_request_arguments()
+        self._assert_default_timeout_setting(req_args)
+
+# ** new_instance
+# ***************
+
+    def test_timeout_new_instance(self):
+        self.cloudant = CloudantV1.new_instance(service_name='SERVER')
+
+        # Mock out request response
+        self._mock_out_cloudant_request()
+
+        # Call the server
+        self.cloudant.get_server_information()
+
+        # Assert timeout is set in the server request
+        req_args=self._get_request_arguments()
+        self._assert_default_timeout_setting(req_args)
+
+# ** Allow timeout overwrite
+# ***************
+
+    def test_timeout_new_instance_overwrite(self):
+        self.cloudant = CloudantV1.new_instance(service_name='SERVER')
+
+        # Overwrite timeout
+        self.cloudant.set_http_config({'timeout':10})
+
+        # Mock out request response
+        self._mock_out_cloudant_request()
+
+        # Call the server
+        self.cloudant.get_server_information()
+
+        # Assert timeout is set in the server request
+        req_args=self._get_request_arguments()
+        self._assert_custom_timeout_setting(req_args)
+
+def test_timeout_cloudantV1_IAMAuth_overwrite(self):
+        authenticator = IAMAuthenticator('apikey')
+        self.cloudant = CloudantV1(
+            authenticator=authenticator
+        )
+
+        # Overwrite timeout
+        self.cloudant.set_http_config({'timeout':10})
+
+        # Mock out authentication
+        self._mock_out_authenticate_request()
+        self.cloudant.authenticator.token_manager._save_token_info=Mock()
+        self.cloudant.authenticator.token_manager.refresh_time = int(time.time()) + 60
+
+        # Mock out request response
+        self._mock_out_cloudant_request()
+
+        # Call the server
+        self.cloudant.get_server_information()
+
+        # Assert timeout is set to the authenticator
+        auth_args = self._get_authenticate_arguments()
+        self._assert_custom_timeout_setting(auth_args)
+
+        # Assert timeout is set in the server request
+        req_args=self._get_request_arguments()
+        self._assert_custom_timeout_setting(req_args)
+
+

--- a/test/integration/test_timeout.py
+++ b/test/integration/test_timeout.py
@@ -49,15 +49,16 @@ class Helpers():
     def mock_out_cloudant_request(srv):
         srv.http_client.request = Mock(return_value=Helpers.get_mocked_response())
 
-    # Every test case tests an authenticator and its default timeout value at first,
-    # in the second iteration a custom overwrite possibility is checked.
+    # Every test case tests a timeout settings.
     @staticmethod
     def defineTestCases(srv):
         return [
+            # 1. case: check default timeout value
             {
                 'assert_func': Helpers.assert_default_timeout_setting,
                 'set_timeout': Helpers.set_no_timeout
             },
+            # 2. case: check custom timeout overwrite
             {
                 'assert_func': Helpers.assert_custom_timeout_setting,
                 'set_timeout': srv.set_http_config
@@ -89,10 +90,10 @@ class Helpers():
         tci.assertEqual(srv.http_client.request.call_count, idx + 1)
         return srv.http_client.request.mock_calls[idx]
 
+# Every method tests an authenticator.
 class TestTimeout(unittest.TestCase):
     # ** CloudantV1
     # *************
-    # Check every authenticator type
     def test_timeout_cloudantv1_noauth(self):
         no_auth = NoAuthAuthenticator()
         my_service = CloudantV1(


### PR DESCRIPTION
- Checked all type of authenticator

## PR summary

<!-- please include a brief summary of the changes in this PR -->

Fixes: <! -- link to issue -->

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently the default read timeout value is 60 seconds.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
Extended this timeout to 2.5 minutes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

The default timeout setting ( by the core) placed almost right before the request sent out, this why I selected to mock out the send request methods.
There is a [ default request timeout](https://github.com/IBM/python-sdk-core/blob/9c8d90ac890d880373e1a0ed54d4fbead35c226c/ibm_cloud_sdk_core/base_service.py#L282)
and a [default authenticate timeout](https://github.com/IBM/python-sdk-core/blob/9c8d90ac890d880373e1a0ed54d4fbead35c226c/ibm_cloud_sdk_core/token_managers/jwt_token_manager.py#L87)
