### PR TITLE
Support alias env var AUTHTYPE

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "stubs/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-11-08T16:55:15Z",
+  "generated_at": "2021-12-22T16:38:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -102,7 +102,7 @@
         "hashed_secret": "5788c5ac01fd15d76b11bacbb480f7bc9f38bee3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 13721,
+        "line_number": 13793,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -128,7 +128,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibmcloudant/couchdb_session_get_authenticator_patch.py
+++ b/ibmcloudant/couchdb_session_get_authenticator_patch.py
@@ -23,7 +23,13 @@ old_construct_authenticator = get_authenticator.__construct_authenticator
 
 
 def new_construct_authenticator(config):  # pylint: disable=missing-docstring
-    auth_type = config.get('AUTH_TYPE').upper() if config.get('AUTH_TYPE') else ''
+    if config.get('AUTH_TYPE'):
+        auth_type = config.get('AUTH_TYPE').upper()
+    elif config.get('AUTHTYPE'):
+        auth_type = config.get('AUTHTYPE').upper()
+    else:
+        auth_type = ''
+
     if auth_type == 'COUCHDB_SESSION':
         return CouchDbSessionAuthenticator(
             username=config.get('USERNAME'),

--- a/test/unit/test_couchdb_session_auth.py
+++ b/test/unit/test_couchdb_session_auth.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2020.
+# © Copyright IBM Corporation 2020, 2021.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import datetime
 import json
 import unittest
 
+import os
 import requests
 import responses
 import time
@@ -163,3 +164,24 @@ class TestCouchDbSessionAuth(unittest.TestCase):
         self.assertEqual(responses.calls[-2].request.method, "POST")
         self.assertEqual(responses.calls[-1].request.url, "http://cloudant2.example/_session")
         self.assertEqual(responses.calls[-1].request.method, "GET")
+
+
+class TestCouchDbSessionAuthPatch(unittest.TestCase):
+
+    def test_new_instance(self):
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'couchdb_session'
+        os.environ['TEST_SERVICE_USERNAME'] = 'adm'
+        os.environ['TEST_SERVICE_PASSWORD'] = 'pass'
+        service = CloudantV1.new_instance(service_name='TEST_SERVICE')
+        self.assertIsNotNone(service)
+        self.assertIsInstance(service, CloudantV1)
+        self.assertEqual('COUCHDB_SESSION', service.authenticator.authentication_type())
+
+    def test_new_instance_auth_alias(self):
+        os.environ['TEST_SERVICE_AUTHTYPE'] = 'couchdb_session'
+        os.environ['TEST_SERVICE_USERNAME'] = 'adm'
+        os.environ['TEST_SERVICE_PASSWORD'] = 'pass'
+        service = CloudantV1.new_instance(service_name='TEST_SERVICE')
+        self.assertIsNotNone(service)
+        self.assertIsInstance(service, CloudantV1)
+        self.assertEqual('COUCHDB_SESSION', service.authenticator.authentication_type())


### PR DESCRIPTION
## PR summary

Support a env var name alias `AUTHTYPE` for `AUTH_TYPE` to keep core's compatibility

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Env var of format `SERVICE_AUTHTYPE` is ignored and error thrown on missing required variable

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
Env var of format `SERVICE_AUTHTYPE` accepted as a valid variable same as `SERVICE_AUTH_TYPE`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
