### PR TITLE
Validate trailing slash stripped on setting of service URL

### DIFF
--- a/test/unit/test_cloudant_base_validation.py
+++ b/test/unit/test_cloudant_base_validation.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2021.
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,3 +46,10 @@ class TestValidation(unittest.TestCase):
         service.set_service_url('https://cloudant.example/some/proxy/path')
         with self.assertRaisesRegex(ValueError, '.+_testDocument.+') as cm:
             service.get_document('testDatabase', '_testDocument')
+
+    def test_validates_strip_trailing_slash(self):
+        service = CloudantV1(
+            authenticator=NoAuthAuthenticator()
+        )
+        service.set_service_url('https://cloudant.example/')
+        self.assertEqual(service.service_url, 'https://cloudant.example')

--- a/test/unit/test_cloudant_base_validation.py
+++ b/test/unit/test_cloudant_base_validation.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2021, 2022
+# © Copyright IBM Corporation 2021, 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## PR summary

Add a test to validate that we are stripping a trailing slash on setting of service URL. The test for env file is not necessary, since it's using the same `set_service_url` function under the hood.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
