### PR TITLE
docs: improve description of rev requirements for post/put document

### DIFF
--- a/test/examples/src/create_db_and_doc.py
+++ b/test/examples/src/create_db_and_doc.py
@@ -50,7 +50,7 @@ example_document: Document = Document(id=example_doc_id)
 
 # Add "name" and "joined" fields to the document
 example_document.name = "Bob Smith"
-example_document.joined = "2019-01-24T10:42:99.000Z"
+example_document.joined = "2019-01-24T10:42:59.000Z"
 
 # Save the document in the database with "post_document" function
 create_document_response = client.post_document(

--- a/test/examples/src/create_db_and_doc.py
+++ b/test/examples/src/create_db_and_doc.py
@@ -1,3 +1,19 @@
+# coding: utf-8
+
+# © Copyright IBM Corporation 2020, 2022.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from ibm_cloud_sdk_core import ApiException
@@ -6,10 +22,10 @@ from ibmcloudant.cloudant_v1 import CloudantV1, Document
 # Set logging level to show only critical logs
 logging.basicConfig(level=logging.CRITICAL)
 
-# 1. Create a client with `CLOUDANT` default service name ============
+# 1. Create a client with `CLOUDANT` default service name =============
 client = CloudantV1.new_instance()
 
-# 2. Create a database ===============================================
+# 2. Create a database ================================================
 example_db_name = "orders"
 
 # Try to create database if it doesn't exist
@@ -24,21 +40,37 @@ except ApiException as ae:
         print(f'Cannot create "{example_db_name}" database, ' +
               'it already exists.')
 
-# 3. Create a document ===============================================
+# 3. Create a document ================================================
 # Create a document object with "example" id
 example_doc_id = "example"
+# Setting `id` for the document is optional when "post_document"
+# function is used for CREATE. When `id` is not provided the server
+# will generate one for your document.
 example_document: Document = Document(id=example_doc_id)
 
 # Add "name" and "joined" fields to the document
 example_document.name = "Bob Smith"
 example_document.joined = "2019-01-24T10:42:99.000Z"
 
-# Save the document in the database
+# Save the document in the database with "post_document" function
 create_document_response = client.post_document(
     db=example_db_name,
     document=example_document
 ).get_result()
 
-# Keep track of the revision number from the `example` document object
+# =====================================================================
+# Note: saving the document can also be done with the "put_document"
+# function. In this case `doc_id` is required for a CREATE operation:
+"""
+create_document_response = client.put_document(
+    db=example_db_name,
+    doc_id=example_doc_id,
+    document=example_document
+).get_result()
+"""
+# =====================================================================
+
+# Keeping track of the revision number of the document object
+# is necessary for further UPDATE/DELETE operations:
 example_document.rev = create_document_response["rev"]
 print(f'You have created the document:\n{example_document}')

--- a/test/examples/src/delete_doc.py
+++ b/test/examples/src/delete_doc.py
@@ -1,3 +1,19 @@
+# coding: utf-8
+
+# © Copyright IBM Corporation 2020, 2022.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from ibm_cloud_sdk_core import ApiException
@@ -6,10 +22,10 @@ from ibmcloudant.cloudant_v1 import CloudantV1
 # Set logging level to show only critical logs
 logging.basicConfig(level=logging.CRITICAL)
 
-# 1. Create a client with `CLOUDANT` default service name ============
+# 1. Create a client with `CLOUDANT` default service name =============
 client = CloudantV1.new_instance()
 
-# 2. Delete the document =============================================
+# 2. Delete the document ==============================================
 example_db_name = "orders"
 example_doc_id = "example"
 
@@ -22,8 +38,8 @@ try:
 
     delete_document_response = client.delete_document(
         db=example_db_name,
-        doc_id=example_doc_id,
-        rev=document["_rev"]
+        doc_id=example_doc_id,  # `doc_id` is required for DELETE
+        rev=document["_rev"]    # `rev` is required for DELETE
     ).get_result()
 
     if delete_document_response["ok"]:

--- a/test/examples/src/get_info_from_existing_database.py
+++ b/test/examples/src/get_info_from_existing_database.py
@@ -1,3 +1,19 @@
+# coding: utf-8
+
+# © Copyright IBM Corporation 2020, 2022.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 
 from ibmcloudant.cloudant_v1 import CloudantV1

--- a/test/examples/src/update_doc.py
+++ b/test/examples/src/update_doc.py
@@ -1,3 +1,19 @@
+# coding: utf-8
+
+# © Copyright IBM Corporation 2020, 2022.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import logging
 
@@ -7,10 +23,10 @@ from ibmcloudant.cloudant_v1 import CloudantV1
 # Set logging level to show only critical logs
 logging.basicConfig(level=logging.CRITICAL)
 
-# 1. Create a client with `CLOUDANT` default service name ============
+# 1. Create a client with `CLOUDANT` default service name =============
 client = CloudantV1.new_instance()
 
-# 2. Update the document =============================================
+# 2. Update the document ==============================================
 example_db_name = "orders"
 example_doc_id = "example"
 
@@ -21,11 +37,15 @@ try:
         doc_id=example_doc_id
     ).get_result()
 
+    # =================================================================
     # Note: for response byte stream use:
-    # document_as_byte_stream = client.get_document_as_stream(
-    #     db=example_db_name,
-    #     doc_id=example_doc_id
-    # ).get_result()
+    """
+    document_as_byte_stream = client.get_document_as_stream(
+        db=example_db_name,
+        doc_id=example_doc_id
+    ).get_result()
+    """
+    # =================================================================
 
     #  Add Bob Smith's address to the document
     document["address"] = "19 Front Street, Darlington, DL5 1TY"
@@ -40,13 +60,33 @@ try:
         document=document
     ).get_result()
 
-    # Note: for request byte stream use:
-    # update_document_response = client.post_document(
-    #     db=example_db_name,
-    #     document=document_as_byte_stream
-    # ).get_result()
+    # =================================================================
+    # Note 1: for request byte stream use:
+    """
+    update_document_response = client.post_document(
+        db=example_db_name,
+        document=document_as_byte_stream
+    ).get_result()
+    """
+    # =================================================================
 
-    # Keep track with the revision number of the document object:
+    # =================================================================
+    # Note 2: updating the document can also be done with the
+    # "put_document" function. `doc_id` and `rev` are required for an
+    # UPDATE operation, but `rev` can be provided in the document
+    # object as `_rev` too:
+    """
+    update_document_response = client.put_document(
+        db=example_db_name,
+        doc_id=example_doc_id,  # doc_id is a required parameter
+        rev=document["_rev"],
+        document=document  # _rev in the document object CAN replace above `rev` parameter
+    ).get_result()
+    """
+    # =================================================================
+
+    # Keeping track of the latest revision number of the document
+    # object is necessary for further UPDATE/DELETE operations:
     document["_rev"] = update_document_response["rev"]
     print(f'You have updated the document:\n' +
           json.dumps(document, indent=2))


### PR DESCRIPTION
## PR summary

The goal of this PR is to improve the description of `_rev`/`rev` requirements for post/put document. I also fixed the ornamentation comment lines to 72 char length because I caught those not shared the same length. I also tried to explain where `_id`/`docId` is necessary similarly to `_rev`/`rev`.

I decided to use `"""...code is here..."""` for code comments and ornamentation lines before and after the explanation plus the commented out codes because with this way maybe the eyes can catch what belongs to what. Something like this:

```python
#/ ========================================================================
# Note: the next code bla bla bla..:
"""
code is here
"""
# ========================================================================
```

I also added missing copyright headers to the examples.

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Lack of explanation around the usage of id and rev fields in CUD operation examples.

## What is the new behavior?
Explanation in example code how to use `putDocument` along with `postDocument` and:
* `_id` is a MUST at CREATE for `putDocument`
* `_id` is OPTIONAL at CREATE for `postDocument`
* `_id` is generated at CREATE when it is not provided `postDocument`
* `_id` and `_rev` is a MUST at UPDATE
*  `id` parameter is a MUST at UPDATE for `putDocument`
* `rev` parameter can be replaced by `_rev` in the document object both for `postDocument` and `putDocument`
* `id` and `rev` parameter is a MUST at DELETE 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
