### PR TITLE
fix: add missing operation names to path validator

### DIFF
--- a/ibmcloudant/cloudant_base_service.py
+++ b/ibmcloudant/cloudant_base_service.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2020, 2021.
+# © Copyright IBM Corporation 2020, 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ class ValidationRule(namedtuple('ValidationRule', ['path_segment_index', 'error_
 doc_id_rule = ValidationRule(path_segment_index=1, error_parameter_name='Document ID', operation_ids= [
     'delete_document',
     'get_document',
+    'get_document_as_mixed',
+    'get_document_as_related',
+    'get_document_as_stream',
     'head_document',
     'put_document',
     'delete_attachment',

--- a/test/unit/test_cloudant_base_validation.py
+++ b/test/unit/test_cloudant_base_validation.py
@@ -28,6 +28,14 @@ class TestValidation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, '.+_testDocument.+') as cm:
             service.get_document('testDatabase', '_testDocument')
 
+    def test_validates_doc_id_with_as_stream_operation(self):
+        service = CloudantV1(
+            authenticator=NoAuthAuthenticator()
+        )
+        service.set_service_url('https://cloudant.example')
+        with self.assertRaisesRegex(ValueError, '.+_testDocument.+') as cm:
+            service.get_document_as_stream('testDatabase', '_testDocument')
+
     def test_validates_doc_id_at_long_service_path(self):
         service = CloudantV1(
             authenticator=NoAuthAuthenticator()


### PR DESCRIPTION
## PR summary

add missing operation names to path validator

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Not all operations have paths validated

## What is the new behavior?
Validate paths additionally on

`get_document_as_mixed`
`get_document_as_related`
`get_document_as_stream`

## Does this PR introduce a breaking change?

- [x] Yes - _only if previous users relied on previous behaviour_
- [ ] No

migration path: any applications which use special paths for the above operations should use the correct operation, eg one of the `*all_docs*` methods in the case of the `_all_docs` path.

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
