### PR TITLE
Make couch session authenticator to support `AUTH_DISABLE_SSL` env var

### DIFF
--- a/ibmcloudant/cloudant_base_service.py
+++ b/ibmcloudant/cloudant_base_service.py
@@ -113,7 +113,7 @@ def new_set_default_headers(self, headers: Dict[str, str]):
 old_set_disable_ssl_verification = CloudantV1.set_disable_ssl_verification
 
 
-def new_set_disable_ssl_verification(self, status: bool = False) -> None:  
+def new_set_disable_ssl_verification(self, status: bool = False) -> None:
     old_set_disable_ssl_verification(self, status)
     if isinstance(self.authenticator, CouchDbSessionAuthenticator):
         self.authenticator.token_manager.set_disable_ssl_verification(status)
@@ -154,6 +154,6 @@ def new_prepare_request(self,
             if len(request_url_path_segments) > rule.path_segment_index:
                 segment_to_validate = request_url_path_segments[rule.path_segment_index]
                 if segment_to_validate.startswith('_'):
-                    raise ValueError('{0} {1} starts with the invalid _ character.'.format(rule.error_parameter_name, 
+                    raise ValueError('{0} {1} starts with the invalid _ character.'.format(rule.error_parameter_name,
                         unquote(segment_to_validate)))
     return old_prepare_request(self, method, url, *args, headers=headers, params=params, data=data, files=files, **kwargs)

--- a/ibmcloudant/couchdb_session_authenticator.py
+++ b/ibmcloudant/couchdb_session_authenticator.py
@@ -39,10 +39,20 @@ class CouchDbSessionAuthenticator(Authenticator):
 
     AUTHTYPE_COUCHDB_SESSION = 'COUCHDB_SESSION'
 
-    def __init__(self, username: str, password: str):
+    def __init__(self,
+                 username: str,
+                 password: str,
+                 disable_ssl_verification: bool = False) -> None:
+        if not isinstance(disable_ssl_verification, bool):
+            raise TypeError('disable_ssl_verification must be a bool')
+
         self.jar = None
 
-        self.token_manager = CouchDbSessionTokenManager(username, password)
+        self.token_manager = CouchDbSessionTokenManager(
+            username,
+            password,
+            disable_ssl_verification=disable_ssl_verification
+        )
         self.validate()
 
     def set_jar(self, jar):

--- a/ibmcloudant/couchdb_session_authenticator.py
+++ b/ibmcloudant/couchdb_session_authenticator.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2020.
+# © Copyright IBM Corporation 2020, 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ibmcloudant/couchdb_session_get_authenticator_patch.py
+++ b/ibmcloudant/couchdb_session_get_authenticator_patch.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2020, 2021.
+# © Copyright IBM Corporation 2020, 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ibmcloudant/couchdb_session_get_authenticator_patch.py
+++ b/ibmcloudant/couchdb_session_get_authenticator_patch.py
@@ -33,6 +33,9 @@ def new_construct_authenticator(config):  # pylint: disable=missing-docstring
     if auth_type == 'COUCHDB_SESSION':
         return CouchDbSessionAuthenticator(
             username=config.get('USERNAME'),
-            password=config.get('PASSWORD')
+            password=config.get('PASSWORD'),
+            disable_ssl_verification=config.get(
+                'AUTH_DISABLE_SSL',
+                config.get('DISABLE_SSL', 'false')).lower() == 'true'
         )
     return old_construct_authenticator(config)

--- a/ibmcloudant/couchdb_session_token_manager.py
+++ b/ibmcloudant/couchdb_session_token_manager.py
@@ -41,8 +41,12 @@ class CouchDbSessionTokenManager(TokenManager):
 
     def __init__(self, username: str, password: str,
                  url: str = None,
+                 disable_ssl_verification: bool = False,
                  ):
-        super().__init__(url)
+        super().__init__(
+            url,
+            disable_ssl_verification=disable_ssl_verification,
+        )
         self.username = username
         self.password = password
 

--- a/test/unit/test_couchdb_session_auth.py
+++ b/test/unit/test_couchdb_session_auth.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2020, 2021.
+# © Copyright IBM Corporation 2020, 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unit/test_couchdb_session_auth.py
+++ b/test/unit/test_couchdb_session_auth.py
@@ -108,6 +108,22 @@ class TestCouchDbSessionAuth(unittest.TestCase):
         finally:
             self.client.set_http_client(original_http_client)
 
+    def test_valid_disable_ssl_verification_type(self):
+        authenticator = CouchDbSessionAuthenticator("adm", "pass")
+        self.assertFalse(authenticator.token_manager.disable_ssl_verification)
+        authenticator = CouchDbSessionAuthenticator(
+            "adm",
+            "pass",
+            disable_ssl_verification=False
+        )
+        self.assertFalse(authenticator.token_manager.disable_ssl_verification)
+        authenticator = CouchDbSessionAuthenticator(
+            "adm",
+            "pass",
+            disable_ssl_verification=True
+        )
+        self.assertTrue(authenticator.token_manager.disable_ssl_verification)
+
     def test_invalid_disable_ssl_verification_type(self):
         with self.assertRaisesRegex(
             TypeError, 'disable_ssl_verification must be a bool'


### PR DESCRIPTION
## PR summary

AN authenticator `CouchDbSessionAuthenticator` throws an exception on self-signed cert even when `CLOUDANT_DISABLE_SSL` variable set to true.

There are new env var `AUTH_DISABLE_SSL` in core-sdk that allows to skip cert validation for authenticators, but `CouchDbSessionAuthenticator` doesn't support it.

Fixes: #326 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Exception on access to `_sessions` end-point for services with self-signed SSL certificate

## What is the new behavior?

Value of env var `DISABLE_SSL` respected for both service and authenticator and `CouchDbSessionAuthenticator` supports specific `AUTH_DISABLE_SSL` env var.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
