### PR TITLE
fix: switch to comma separated passenv in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands = pylint --rcfile=.pylintrc ibmcloudant test
 setenv = PYTHONPATH = pylint/checkers
 
 [testenv]
-passenv = TOXENV CI TRAVIS*
+passenv = TOXENV, CI, TRAVIS*
 commands =
          py.test --reruns 3 -o junit_family=xunit2 --junitxml=junitreports/junit-{envname}.xml --cov=ibmcloudant {posargs}
 deps =


### PR DESCRIPTION
## PR summary

Tox in 4.0 switched to comma separated list in `passenv` instead of space separated https://tox.wiki/en/4.0.3/faq.html#tox-4-changed-ini-rules

That was fine for us so far since prior 4.6 tox accepted both variants, but now it was mitigated, so we need to update our `tox.ini` to let tox bump pass

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
