### PR TITLE
fix(docs): pin asteroid lib to 2.x to fix autodoc2 analyzer

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,3 +4,4 @@ Sphinx==7.2.6
 sphinx-autodoc2==0.4.2
 myst-parser==2.0.0
 sphinx-rtd-theme==1.3.0
+astroid==2.15.8


### PR DESCRIPTION
## PR summary

Apparently autodoc2 dep asteroid version 3 breaks the plugin and it was installed implicitly to >= 3 since it hasn't been pined in autodoc2 deps.

This PR pins asteroid to current 2.x version for time been to allow docs to be build. 

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
