### PR TITLE
Bump allowed runtime slack in follower's tests

### DIFF
--- a/test/unit/features/test_changes_follower.py
+++ b/test/unit/features/test_changes_follower.py
@@ -196,7 +196,7 @@ class TestChangesFollowerFinite(ChangesFollowerBaseCase):
             stop = timeit.default_timer() - start
             self.assertLess(
                 stop,
-                0.100,
+                0.300,
                 'There should be no exception delay.',
             )
 


### PR DESCRIPTION
## PR summary

In follower's test for no suppression run we expect exception to be reported immediately, but ofc it takes some time to start follower and do the request, so we gave the test 100ms slack for the report time. Apparently this is not enough on busy Jenkins and an actual delay can approach 160-200ms

This PR bumps the slack to 300ms just to be on a safe side, as there is no good way to determine if there really were no suppression in follower, but 300ms is still good enough to assume that.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
