### PR TITLE
fix: remove deprecated timezone.utc from changes follower

### DIFF
--- a/ibmcloudant/features/changes_follower.py
+++ b/ibmcloudant/features/changes_follower.py
@@ -20,7 +20,7 @@ import logging
 import time
 import random
 import math
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 import functools
 from queue import Queue
 from threading import Thread, Event
@@ -98,7 +98,7 @@ class ChangesFollowerIterator:
             self._transient_suppression = TransientErrorSuppression.ALWAYS
         self.error_tolerance = timedelta(milliseconds=error_tolerance)
         self.since = 'now' if mode is Mode.LISTEN else '0'
-        self._success_timestamp = datetime.now(timezone.utc)
+        self._success_timestamp = datetime.now(datetime.UTC)
         self._request_thread = Thread(target=self._request_callback)
         self._buffer = Queue()
         self._pending = None
@@ -170,7 +170,7 @@ class ChangesFollowerIterator:
                 self._pending = result.get('pending')
                 self._retry = 0
                 if self._transient_suppression == TransientErrorSuppression.TIMER:
-                    self._success_timestamp = datetime.now(timezone.utc)
+                    self._success_timestamp = datetime.now(datetime.UTC)
                 if self.mode == Mode.FINITE and self._pending == 0:
                     self._has_next = False
                 results = result['results']
@@ -189,7 +189,7 @@ class ChangesFollowerIterator:
                         self._transient_suppression
                         == TransientErrorSuppression.TIMER
                         and self._success_timestamp + self.error_tolerance
-                        < datetime.now(timezone.utc)
+                        < datetime.now(datetime.UTC)
                     )
                 ):
                     self.logger.debug('Error tolerance deadline exceeded.')

--- a/ibmcloudant/features/changes_follower.py
+++ b/ibmcloudant/features/changes_follower.py
@@ -24,11 +24,6 @@ from datetime import datetime, timedelta
 import functools
 from queue import Queue
 from threading import Thread, Event
-try:
-    from datetime import UTC
-except ImportError:
-    from datetime import timezone
-    UTC = timezone.utc
 
 from enum import Enum, auto
 from typing import Dict, Iterator
@@ -103,7 +98,7 @@ class ChangesFollowerIterator:
             self._transient_suppression = TransientErrorSuppression.ALWAYS
         self.error_tolerance = timedelta(milliseconds=error_tolerance)
         self.since = 'now' if mode is Mode.LISTEN else '0'
-        self._success_timestamp = datetime.now(UTC)
+        self._success_timestamp = datetime.utcnow()
         self._request_thread = Thread(target=self._request_callback)
         self._buffer = Queue()
         self._pending = None
@@ -175,7 +170,7 @@ class ChangesFollowerIterator:
                 self._pending = result.get('pending')
                 self._retry = 0
                 if self._transient_suppression == TransientErrorSuppression.TIMER:
-                    self._success_timestamp = datetime.now(UTC)
+                    self._success_timestamp = datetime.utcnow()
                 if self.mode == Mode.FINITE and self._pending == 0:
                     self._has_next = False
                 results = result['results']
@@ -194,7 +189,7 @@ class ChangesFollowerIterator:
                         self._transient_suppression
                         == TransientErrorSuppression.TIMER
                         and self._success_timestamp + self.error_tolerance
-                        < datetime.now(UTC)
+                        < datetime.utcnow()
                     )
                 ):
                     self.logger.debug('Error tolerance deadline exceeded.')


### PR DESCRIPTION
## PR summary

Remove deprecated `timezone.utc` for `datetime.UTC` from changes follower.

Fixes: #565 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
