### PR TITLE
fix(docs): revert astroid pin

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,4 +4,3 @@ Sphinx==7.2.6
 sphinx-autodoc2==0.4.2
 myst-parser==2.0.0
 sphinx-rtd-theme==1.3.0
-astroid==2.15.8


### PR DESCRIPTION
## PR summary

New version of autodocs2 is out, so we don't need to pin astroid to old version anymore.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
