### PR TITLE
fix(test): Drain counter queue in follower's runner

### DIFF
--- a/test/unit/features/conftest.py
+++ b/test/unit/features/conftest.py
@@ -39,7 +39,11 @@ from ibmcloudant.cloudant_v1 import (
     ChangesResultItem,
 )
 
-from ibmcloudant.features.changes_follower import _LONGPOLL_TIMEOUT, _BATCH_SIZE, _Mode
+from ibmcloudant.features.changes_follower import (
+    _LONGPOLL_TIMEOUT,
+    _BATCH_SIZE,
+    _Mode,
+)
 
 
 @pytest.fixture(scope='class')
@@ -112,7 +116,13 @@ class ChangesFollowerBaseCase(unittest.TestCase):
             service_name='TEST_SERVICE',
         )
 
-    def prepare_mock_changes(self, batches=0, errors=[], db_info_doc_count=500_000, db_info_doc_size=523):
+    def prepare_mock_changes(
+        self,
+        batches=0,
+        errors=[],
+        db_info_doc_count=500_000,
+        db_info_doc_size=523,
+    ):
         class changes_callback:
             def __init__(self):
                 self._batch_num = 1
@@ -171,7 +181,10 @@ class ChangesFollowerBaseCase(unittest.TestCase):
             url,
             status=200,
             content_type='application/json',
-            json={'doc_count': db_info_doc_count, 'sizes': {'external': db_info_doc_count * db_info_doc_size}},
+            json={
+                'doc_count': db_info_doc_count,
+                'sizes': {'external': db_info_doc_count * db_info_doc_size},
+            },
         )
 
         url = _base_url + '/db/_changes'

--- a/test/unit/features/test_changes_follower.py
+++ b/test/unit/features/test_changes_follower.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# © Copyright IBM Corporation 2022, 2023.
+# © Copyright IBM Corporation 2022, 2024.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -458,7 +458,7 @@ class TestChangesFollowerListen(ChangesFollowerBaseCase):
         with some batches.
         """
         try:
-            self.prepare_mock_changes(batches=MAX_BATCHES)
+            self.prepare_mock_changes(batches=3)
             follower = ChangesFollower(self.client, db='db')
             count = self.runner(follower, _Mode.LISTEN, timeout=5)
         except BaseException:


### PR DESCRIPTION
## PR summary

Tweak follower's runner logic in followers test fixtures to address the issue when follower fails to return final count on constrained Jenkins servers.

Fixes: #584 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Periodically we are failing counter condition on tests with timeout when we are stopping the follower before it finish processing all the changes. 

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Instead of waiting for looper to stop and return final coutner we push all updates into queue and then drain it from main loop after thread joined or times out.

This makes timeout tests into soft timeout, because we are giving looper time to finish processing last batch of the changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
