### PR TITLE
refactor: replace ApiException 'code' with 'status_code'

### DIFF
--- a/ibmcloudant/features/changes_follower.py
+++ b/ibmcloudant/features/changes_follower.py
@@ -197,7 +197,7 @@ class _ChangesFollowerIterator:
                     self._buffer.put(e)
                     break
                 if (
-                    type(e) is ApiException and e.code in [400, 401, 403, 404]
+                    type(e) is ApiException and e.status_code in [400, 401, 403, 404]
                     or type(e) is StopIteration
                 ):
                     self.logger.debug('Terminal error.')

--- a/test/examples/src/create_db_and_doc.py
+++ b/test/examples/src/create_db_and_doc.py
@@ -31,7 +31,7 @@ try:
     if put_database_result["ok"]:
         print(f'"{example_db_name}" database created.')
 except ApiException as ae:
-    if ae.code == 412:
+    if ae.status_code == 412:
         print(f'Cannot create "{example_db_name}" database, ' +
               'it already exists.')
 

--- a/test/examples/src/delete_doc.py
+++ b/test/examples/src/delete_doc.py
@@ -41,7 +41,7 @@ try:
         print('You have deleted the document.')
 
 except ApiException as ae:
-    if ae.code == 404:
+    if ae.status_code == 404:
         print('Cannot delete document because either ' +
               f'"{example_db_name}" database or "{example_doc_id}"' +
               'document was not found.')

--- a/test/examples/src/update_doc.py
+++ b/test/examples/src/update_doc.py
@@ -88,7 +88,7 @@ try:
           json.dumps(document, indent=2))
 
 except ApiException as ae:
-    if ae.code == 404:
+    if ae.status_code == 404:
         print('Cannot delete document because either ' +
               f'"{example_db_name}" database or "{example_doc_id}" ' +
               'document was not found.')


### PR DESCRIPTION
## PR summary
The `code` attribute of `ApiException` was recently deprecated in `python-sdk-core`.
This work replaces `code` with the new `status_code` attribute.

Python sdk core PR: https://github.com/IBM/python-sdk-core/pull/185 
<!-- please include a brief summary of the changes in this PR -->

Fixes: s889


## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
