### PR TITLE
build(deps): `requests>=2.32.2,<3.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.8.2"
 description = "Python client library for IBM Cloudant"
 dependencies = [
   "ibm_cloud_sdk_core==3.20.2",
-  "requests>=2.32.0,<2.32.3",
+  "requests>=2.32.2,<3.0.0",
   "python_dateutil>=2.5.3,<3.0.0",
   "PyJWT>=2.0.1,<3.0.0",
 ]


### PR DESCRIPTION
## PR summary

Restore the `requests` dependency range now that https://github.com/IBM/python-sdk-core/releases/tag/v3.20.2 is available.

Related to #660 and #676

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe)

Dependency update.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`requests` dependency is pinned to a small range avoiding the broken `2.32.3` version.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Since the core now has a workaround for the broken behaviour in `2.32.3` we can relax the range again `requests>=2.32.2,<3.0.0`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
