### PR TITLE
Stabilize follower tests

### DIFF
--- a/ibmcloudant/features/changes_follower.py
+++ b/ibmcloudant/features/changes_follower.py
@@ -157,7 +157,9 @@ class _ChangesFollowerIterator:
                     raise StopIteration from exc
                 if isinstance(data, Exception):
                     raise data from None
-                self._changes_iter = iter(data)
+                self._changes_iter = iter(
+                    (ChangesResultItem.from_dict(item) for item in data)
+                )
                 self._buffer.task_done()
 
     def _request_callback(self):
@@ -178,9 +180,7 @@ class _ChangesFollowerIterator:
                 self._buffer.join()
                 if self._stop.is_set():
                     raise StopIteration
-                self._buffer.put(
-                    [ChangesResultItem.from_dict(item) for item in results]
-                )
+                self._buffer.put(results)
             except Exception as e:
                 self.logger.debug(f'Exception getting changes {e}')
                 if (

--- a/ibmcloudant/features/changes_follower.py
+++ b/ibmcloudant/features/changes_follower.py
@@ -181,6 +181,11 @@ class _ChangesFollowerIterator:
                 if self._stop.is_set():
                     raise StopIteration
                 self._buffer.put(results)
+            except StopIteration as e:
+                self.logger.debug('Iterator stopped.')
+                self._buffer.join()
+                self._buffer.put(e)
+                break
             except Exception as e:
                 self.logger.debug(f'Exception getting changes {e}')
                 if (
@@ -196,10 +201,7 @@ class _ChangesFollowerIterator:
                     self._buffer.join()
                     self._buffer.put(e)
                     break
-                if (
-                    type(e) is ApiException and e.status_code in [400, 401, 403, 404]
-                    or type(e) is StopIteration
-                ):
+                if type(e) is ApiException and e.status_code in [400, 401, 403, 404]:
                     self.logger.debug('Terminal error.')
                     self._buffer.join()
                     self._buffer.put(e)

--- a/test/unit/features/test_changes_follower.py
+++ b/test/unit/features/test_changes_follower.py
@@ -287,12 +287,12 @@ class TestChangesFollowerFinite(ChangesFollowerBaseCase):
             self.prepare_mock_changes(batches=MAX_BATCHES)
             follower = ChangesFollower(self.client, db="db")
             start = timeit.default_timer()
-            count = self.runner(follower, _Mode.FINITE, timeout=5, stop_after=1000)
+            count = self.runner(follower, _Mode.FINITE, timeout=2, stop_after=1000)
             stop = timeit.default_timer() - start
         except BaseException:
             self.fail("There should be no exception.")
         self.assertGreaterEqual(count, 1000, "There should be some changes.")
-        self.assertLess(stop, 5, "The thread should have stopped before the wait time.")
+        self.assertLess(stop, 2, "The thread should have stopped before the wait time.")
 
     @responses.activate
     def test_state_error(self):
@@ -324,7 +324,7 @@ class TestChangesFollowerFinite(ChangesFollowerBaseCase):
             try:
                 self.prepare_mock_changes(batches=MAX_BATCHES)
                 follower = ChangesFollower(self.client, db="db", limit=limit)
-                count = self.runner(follower, _Mode.FINITE, timeout=3600)
+                count = self.runner(follower, _Mode.FINITE, timeout=180)
             except BaseException:
                 self.fail("There should be no exception.")
             self.assertEqual(
@@ -446,7 +446,7 @@ class TestChangesFollowerListen(ChangesFollowerBaseCase):
         try:
             self.prepare_mock_changes(batches=3)
             follower = ChangesFollower(self.client, db="db")
-            count = self.runner(follower, _Mode.LISTEN, timeout=5)
+            count = self.runner(follower, _Mode.LISTEN, timeout=2)
         except BaseException:
             self.fail("There should be no exception.")
         self.assertGreater(count, 2 * _BATCH_SIZE + 1, "There should be some changes.")
@@ -543,7 +543,7 @@ class TestChangesFollowerListen(ChangesFollowerBaseCase):
         Checks that a LISTEN mode runs through transient errors
         with max suppression to receive changes until stopped.
         """
-        batches = 3
+        batches = 2
         self.prepare_mock_changes(
             batches=batches,
             errors=self.transient_errors,
@@ -568,12 +568,12 @@ class TestChangesFollowerListen(ChangesFollowerBaseCase):
             self.prepare_mock_changes(batches=MAX_BATCHES)
             follower = ChangesFollower(self.client, db="db")
             start = timeit.default_timer()
-            count = self.runner(follower, _Mode.LISTEN, timeout=5, stop_after=1000)
+            count = self.runner(follower, _Mode.LISTEN, timeout=2, stop_after=1000)
             stop = timeit.default_timer() - start
         except BaseException:
             self.fail("There should be no exception.")
         self.assertGreaterEqual(count, 1000, "There should be some changes.")
-        self.assertLess(stop, 5, "The thread should have stopped before the wait time.")
+        self.assertLess(stop, 2, "The thread should have stopped before the wait time.")
 
     @responses.activate
     def test_state_error(self):
@@ -605,7 +605,7 @@ class TestChangesFollowerListen(ChangesFollowerBaseCase):
             try:
                 self.prepare_mock_changes(batches=MAX_BATCHES)
                 follower = ChangesFollower(self.client, db="db", limit=limit)
-                count = self.runner(follower, _Mode.LISTEN, timeout=3600)
+                count = self.runner(follower, _Mode.LISTEN, timeout=180)
             except BaseException:
                 self.fail("There should be no exception.")
             self.assertEqual(


### PR DESCRIPTION
## PR summary

This PR attempts to stabilize CI for follower's tests.

The list of changes:
- Better debug messages that doesn't show iterator stop as an exception
- Shorter timeouts on tests for faster failing on resource starved CI runners
- Simplify and refactor test runner to do iterations on main loop and run stopper in thread as Timer
- Switch to lazy-loading generator expression in main thread of follower to avoid memory and CPU overhead in tread's buffer   

Fixes: s1060

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The CI occasionally hangs or fails on resource starved containers.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

CI should be more stable and fail faster.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
