### PR TITLE
Correctly set since on one off follower

### DIFF
--- a/ibmcloudant/features/changes_follower.py
+++ b/ibmcloudant/features/changes_follower.py
@@ -107,7 +107,6 @@ class _ChangesFollowerIterator:
         self._limit = None
         self._stop = Event()
         self.logger = logging.getLogger(__name__)
-        self._request_thread.start()
 
     @property
     def limit(self) -> int:
@@ -126,6 +125,9 @@ class _ChangesFollowerIterator:
     @since.setter
     def since(self, value: str) -> None:
         self._since = value
+
+    def _start(self) -> None:
+        self._request_thread.start()
 
     def stop(self) -> None:
         # shortcut limit and cancel in-flight
@@ -454,4 +456,5 @@ class ChangesFollower:
             self._iter.limit = self.limit
         if self.options.get('since') is not None:
             self._iter.since = self.options.get('since')
+        self._iter._start()
         return self._iter


### PR DESCRIPTION
## PR summary

Separate starting follower's iterator from initializing it to allow setting since prior pre-fetch.

Fixes: #728 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
