### PR TITLE
feat: set x-request-id as error trace

### DIFF
--- a/ibmcloudant/cloudant_base_service.py
+++ b/ibmcloudant/cloudant_base_service.py
@@ -160,7 +160,10 @@ def _error_response_hook(response:Response, *args, **kwargs) -> Optional[Respons
                             error_json['errors'] = [error_model]
                             send_augmented_response = True
                     if 'errors' in error_json:
-                        trace = response.headers.get('x-couch-request-id')
+                        # Get the x-request-id header if available
+                        # otherwise try the x-couch-request-id header
+                        trace = response.headers.get('x-request-id',
+                                    response.headers.get('x-couch-request-id'))
                         if trace is not None:
                             # Augment trace if there was a value
                             error_json['trace'] = trace

--- a/test/unit/test_cloudant_base_error_augment.py
+++ b/test/unit/test_cloudant_base_error_augment.py
@@ -231,6 +231,31 @@ class TestErrorAugment(unittest.TestCase):
             }
         )
 
+    def test_augment_error_reason_with_trace_request_id(self):
+        self._run_test(
+            mock_response={
+                'body': self._error_reason_body,
+                'headers': self._content_type_header | {'x-request-id': self._req_id},
+                'status': 444
+            },
+            expected_response={
+                'body': self._error_reason_body | self._errors_error_reason | self._trace
+            }
+        )
+
+    def test_augment_error_reason_with_trace_request_id_preferred(self):
+        expected_req_id = 'preferred_req_id'
+        self._run_test(
+            mock_response={
+                'body': self._error_reason_body,
+                'headers': self._default_mock_headers | {'x-request-id': expected_req_id},
+                'status': 444
+            },
+            expected_response={
+                'body': self._error_reason_body | self._errors_error_reason | {'trace': expected_req_id}
+            }
+        )
+
     def test_augment_error_reason_stream(self):
         self._run_test(
             mock_response={


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

If the `x-request-id` header is on a response use it to set the error `trace` field (in preference to `x-couch-request-id`, but still use `x-couch-request-id` if there is no `x-request-id`).

Fixes: part of s1037

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The error `trace` introduced in #719 only handles CouchDB's `x-couch-request-id` header on responses.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

The error `trace` also handles `x-request-id` header on responses.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
