### PR TITLE
refactor(follower): use normal feed for one-off changes

### DIFF
--- a/ibmcloudant/features/changes_follower.py
+++ b/ibmcloudant/features/changes_follower.py
@@ -293,7 +293,7 @@ class ChangesFollower:
     ) -> None:
         self.options = kwargs
         self.limit = self.options.get('limit')
-        self._set_defaults()
+        self._set_defaults(_Mode.FINITE)
         self.service = service
         self.error_tolerance = error_tolerance
         self._iter = None
@@ -358,11 +358,16 @@ class ChangesFollower:
             raise ValueError(error_fmt.format(invalid_opts_list, class_name))
         self._options = value
 
-    def _set_defaults(self, limit: int = None):
-        defaults = {
-            'feed': PostChangesEnums.Feed.LONGPOLL,
-            'timeout': _LONGPOLL_TIMEOUT,
-        }
+    def _set_defaults(self, mode: _Mode, limit: int = None):
+        if mode == _Mode.FINITE:
+            defaults = {
+                'feed': PostChangesEnums.Feed.NORMAL
+            }
+        elif mode == _Mode.LISTEN:
+            defaults = {
+                'feed': PostChangesEnums.Feed.LONGPOLL,
+                'timeout': _LONGPOLL_TIMEOUT,
+            }
         if limit is not None:
             self.logger.debug(f'Applying changes limit {limit}')
             defaults['limit'] = limit
@@ -445,7 +450,7 @@ class ChangesFollower:
         if self.limit is not None:
             batch_size = self.limit if self.limit < batch_size else batch_size
 
-        self._set_defaults(batch_size)
+        self._set_defaults(mode, batch_size)
         changes_caller = functools.partial(
             self.service.post_changes, **self.options
         )

--- a/test/unit/features/test_changes_follower.py
+++ b/test/unit/features/test_changes_follower.py
@@ -113,6 +113,16 @@ class TestChangesFollowerOptions(ChangesFollowerBaseCase):
     def test_set_defaults(self):
         follower = ChangesFollower(self.client, db="db", **self.kwarg_valid)
         expected = {
+            "feed": PostChangesEnums.Feed.NORMAL,
+            "timeout": None,
+        }
+        for opt, val in expected.items():
+            self.assertEqual(follower.options.get(opt), val)
+
+    def test_set_defaults_listen(self):
+        follower = ChangesFollower(self.client, db="db", **self.kwarg_valid)
+        follower._set_defaults(_Mode.LISTEN)
+        expected = {
             "feed": PostChangesEnums.Feed.LONGPOLL,
             "timeout": _LONGPOLL_TIMEOUT,
         }
@@ -121,7 +131,18 @@ class TestChangesFollowerOptions(ChangesFollowerBaseCase):
 
     def test_set_defaults_with_limit(self):
         follower = ChangesFollower(self.client, db="db", **self.kwarg_valid)
-        follower._set_defaults(limit=12)
+        follower._set_defaults(_Mode.FINITE, limit=12)
+        expected = {
+            "feed": PostChangesEnums.Feed.NORMAL,
+            "timeout": None,
+            "limit": 12,
+        }
+        for opt, val in expected.items():
+            self.assertEqual(follower.options.get(opt), val)
+
+    def test_set_defaults_listen_with_limit(self):
+        follower = ChangesFollower(self.client, db="db", **self.kwarg_valid)
+        follower._set_defaults(_Mode.LISTEN, limit=12)
         expected = {
             "feed": PostChangesEnums.Feed.LONGPOLL,
             "timeout": _LONGPOLL_TIMEOUT,
@@ -133,7 +154,7 @@ class TestChangesFollowerOptions(ChangesFollowerBaseCase):
     def test_set_defaults_with_kwarg_limit(self):
         kwarg = {**self.kwarg_valid, **{"limit": 24}}
         follower = ChangesFollower(self.client, db="db", **kwarg)
-        follower._set_defaults(limit=12)
+        follower._set_defaults(_Mode.LISTEN, limit=12)
         self.assertEqual(follower.options.get("limit"), 12)
 
 


### PR DESCRIPTION
## PR summary

Use normal feed mode for changes follower one-off `FINITE` mode.

Fixes: s1115 / i445

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) - performance improvement

## What is the current behavior?

Currently the changes follower uses `longpoll` feed type is for both start (`LISTEN`) and `start_one_off` (`FINITE`) cases.

## What is the new behavior?

Switch to use the normal feed type for `start_one_off` (`FINITE`) mode to avoid waiting unnecessarily till timeout on empty feeds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
