### PR TITLE
fix: disable_ssl_verification impl for CouchDbSessionAuthenticator

### DIFF
--- a/ibmcloudant/__init__.py
+++ b/ibmcloudant/__init__.py
@@ -19,7 +19,7 @@
 from ibm_cloud_sdk_core import IAMTokenManager, DetailedResponse, BaseService, ApiException, get_authenticator
 from .couchdb_session_authenticator import CouchDbSessionAuthenticator
 from .couchdb_session_get_authenticator_patch import new_construct_authenticator
-from .cloudant_base_service import new_init, new_prepare_request, new_set_default_headers, new_set_http_client, new_set_service_url
+from .cloudant_base_service import new_init, new_prepare_request, new_set_default_headers, new_set_http_client, new_set_service_url, new_set_disable_ssl_verification
 from .couchdb_session_token_manager import CouchDbSessionTokenManager
 from .cloudant_v1 import CloudantV1
 from .features.changes_follower import ChangesFollower
@@ -37,3 +37,5 @@ CloudantV1.set_default_headers = new_set_default_headers
 CloudantV1.prepare_request = new_prepare_request
 
 CloudantV1.set_http_client = new_set_http_client
+
+CloudantV1.set_disable_ssl_verification = new_set_disable_ssl_verification

--- a/ibmcloudant/cloudant_base_service.py
+++ b/ibmcloudant/cloudant_base_service.py
@@ -114,9 +114,6 @@ def new_set_default_headers(self, headers: Dict[str, str]):
 
 _old_set_disable_ssl_verification = CloudantV1.set_disable_ssl_verification
 
-# Note this is currently unused, but probably should be enabled.
-# To enable it we need to resolve whether CouchDbSessionAuthenticator
-# should ever be allowed to have a different value from the service client.
 def new_set_disable_ssl_verification(self, status: bool = False) -> None:
     _old_set_disable_ssl_verification(self, status)
     if isinstance(self.authenticator, CouchDbSessionAuthenticator):

--- a/ibmcloudant/couchdb_session_get_authenticator_patch.py
+++ b/ibmcloudant/couchdb_session_get_authenticator_patch.py
@@ -34,8 +34,6 @@ def new_construct_authenticator(config):  # pylint: disable=missing-docstring
         return CouchDbSessionAuthenticator(
             username=config.get('USERNAME'),
             password=config.get('PASSWORD'),
-            disable_ssl_verification=config.get(
-                'AUTH_DISABLE_SSL',
-                config.get('DISABLE_SSL', 'false')).lower() == 'true'
+            disable_ssl_verification=config.get('DISABLE_SSL', 'false').lower() == 'true'
         )
     return old_construct_authenticator(config)

--- a/test/unit/test_couchdb_session_auth.py
+++ b/test/unit/test_couchdb_session_auth.py
@@ -231,30 +231,3 @@ class TestCouchDbSessionAuthPatch(unittest.TestCase):
         self.assertTrue(service.disable_ssl_verification)
         self.assertTrue(
             service.authenticator.token_manager.disable_ssl_verification)
-
-    def test_auth_disable_ssl(self):
-        os.environ['TEST_SERVICE_AUTHTYPE'] = 'couchdb_session'
-        os.environ['TEST_SERVICE_USERNAME'] = 'adm'
-        os.environ['TEST_SERVICE_PASSWORD'] = 'pass'
-        os.environ['TEST_SERVICE_AUTH_DISABLE_SSL'] = 'true'
-        service = CloudantV1.new_instance(service_name='TEST_SERVICE')
-        self.assertIsNotNone(service)
-        self.assertIsInstance(service, CloudantV1)
-        self.assertEqual('COUCHDB_SESSION', service.authenticator.authentication_type())
-        self.assertFalse(service.disable_ssl_verification)
-        self.assertTrue(
-            service.authenticator.token_manager.disable_ssl_verification)
-
-    def test_auth_disable_ssl_only(self):
-        os.environ['TEST_SERVICE_AUTHTYPE'] = 'couchdb_session'
-        os.environ['TEST_SERVICE_USERNAME'] = 'adm'
-        os.environ['TEST_SERVICE_PASSWORD'] = 'pass'
-        os.environ['TEST_SERVICE_DISABLE_SSL'] = 'false'
-        os.environ['TEST_SERVICE_AUTH_DISABLE_SSL'] = 'true'
-        service = CloudantV1.new_instance(service_name='TEST_SERVICE')
-        self.assertIsNotNone(service)
-        self.assertIsInstance(service, CloudantV1)
-        self.assertEqual('COUCHDB_SESSION', service.authenticator.authentication_type())
-        self.assertFalse(service.disable_ssl_verification)
-        self.assertTrue(
-            service.authenticator.token_manager.disable_ssl_verification)


### PR DESCRIPTION
## PR summary

This PR removes support of `AUTH_DISABLE_SSL` for `CouchDbSessionAuthenticator` to keep it in line with other impl and also fixes monkey-patch for `set_disable_ssl_verification` 

Fixes: s1029

**Note: An existing issue is [required](https://github.com/IBM/cloudant-python-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?

We treat settings for `DISABLE_SSL` and `AUTH_DISABLE_SSL` as a separate entries in session auth, so it is possible to have it disabled for client and not for auth and visa versa. This can get confusing, since unlike other auth session queries the same URL 

## What is the new behavior?

Setting for `AUTH_DISABLE_SSL` disregarded and `DISABLE_SSL` treated as a main config. Same time patch to `set_disable_ssl_verification` fixed, so function call works for session auth as well.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->
