### PR TITLE
fix: handle session cookies with no expiry

### DIFF
--- a/ibmcloudant/couchdb_session_token_manager.py
+++ b/ibmcloudant/couchdb_session_token_manager.py
@@ -84,6 +84,8 @@ class CouchDbSessionTokenManager(TokenManager):
 
         return response
 
+    _DEFAULT_SESSION_COOKIE_TTL_SECONDS = 24 * 60 * 60
+
     def _save_token_info(self, token_response) -> None:
         """
         Decode the access token and save the response from the service to the object's state
@@ -100,6 +102,8 @@ class CouchDbSessionTokenManager(TokenManager):
         cookie = next(x for x in self.access_token if x.name == 'AuthSession')
         exp = cookie.expires
         iat = self._get_current_time()
+        if exp is None:
+            exp = iat + self._DEFAULT_SESSION_COOKIE_TTL_SECONDS
         self.expire_time = exp
         ttl = exp - iat
         buffer = ttl * 0.2

--- a/test/unit/test_couchdb_session_auth.py
+++ b/test/unit/test_couchdb_session_auth.py
@@ -25,6 +25,7 @@ import time
 
 from ibmcloudant import CouchDbSessionAuthenticator
 from ibmcloudant.cloudant_v1 import CloudantV1
+from ibmcloudant.couchdb_session_token_manager import CouchDbSessionTokenManager
 
 request = requests.request
 request_args = None
@@ -55,9 +56,12 @@ class TestCouchDbSessionAuth(unittest.TestCase):
 
     def prepare_for_url(self, url):
         def post_session(request):
-            return (200, {
-                "Set-Cookie": "AuthSession=" + self.cookie_value + ";  Version=1; Expires=" +
-                              self.cookie_expire_time + "; Max-Age=600; Path=/; HttpOnly"},
+            if self.cookie_expire_time is None:
+                set_cookie = "AuthSession=" + self.cookie_value + ";  Version=1; Path=/; HttpOnly"
+            else:
+                set_cookie = ("AuthSession=" + self.cookie_value + ";  Version=1; Expires=" +
+                              self.cookie_expire_time + "; Max-Age=600; Path=/; HttpOnly")
+            return (200, {"Set-Cookie": set_cookie},
                     json.dumps({"ok": True, "name": "adm", "roles": ["_admin"]}))
 
         responses.add_callback(responses.POST, url + '/_session', post_session)
@@ -70,6 +74,7 @@ class TestCouchDbSessionAuth(unittest.TestCase):
 
     @responses.activate
     def test_header_passing(self):
+        self.cookie_expire_time = None
         self.client.set_default_headers({"yes": "works"})
         response = self.client.get_session_information(headers={"foo": "bar"})
         self.assertIsNotNone(response)
@@ -86,6 +91,7 @@ class TestCouchDbSessionAuth(unittest.TestCase):
 
     @responses.activate
     def test_disable_ssl_verification_on(self):
+        self.cookie_expire_time = None
         original_http_client = self.client.get_http_client()
         mock_session = MockSession()
         try:
@@ -98,6 +104,7 @@ class TestCouchDbSessionAuth(unittest.TestCase):
 
     @responses.activate
     def test_disable_ssl_verification_off(self):
+        self.cookie_expire_time = None
         original_http_client = self.client.get_http_client()
         mock_session = MockSession()
         try:
@@ -136,6 +143,7 @@ class TestCouchDbSessionAuth(unittest.TestCase):
 
     @responses.activate
     def test_cookie_refresh(self):
+        self.cookie_expire_time = None
         self.client.get_session_information()
         self.assertEqual(responses.calls[-1].request.headers["Cookie"], "AuthSession=foobar")
         self.cookie_value = "bar"
@@ -151,6 +159,7 @@ class TestCouchDbSessionAuth(unittest.TestCase):
 
     @responses.activate
     def test_cookie_expired(self):
+        self.cookie_expire_time = None
         self.client.get_session_information()
         self.assertEqual(responses.calls[-1].request.headers["Cookie"], "AuthSession=foobar")
         self.cookie_value = "bar"
@@ -161,6 +170,7 @@ class TestCouchDbSessionAuth(unittest.TestCase):
 
     @responses.activate
     def test_cookie_not_yet_expired(self):
+        self.cookie_expire_time = None
         self.client.get_session_information()
         self.assertEqual(responses.calls[-1].request.headers["Cookie"], "AuthSession=foobar")
         self.cookie_value = "bar"
@@ -178,7 +188,34 @@ class TestCouchDbSessionAuth(unittest.TestCase):
                                self.authenticator.token_manager._get_current_time() + 8 * 60, delta=3)
 
     @responses.activate
+    def test_refresh_time_calculation_no_expiry(self):
+        self.cookie_expire_time = None
+        self.client.get_session_information()
+        token_manager = self.authenticator.token_manager
+        default_ttl = CouchDbSessionTokenManager._DEFAULT_SESSION_COOKIE_TTL_SECONDS
+        self.assertAlmostEqual(token_manager.expire_time,
+                               token_manager._get_current_time() + default_ttl, delta=3)
+        self.assertAlmostEqual(token_manager.refresh_time,
+                               token_manager._get_current_time() + default_ttl * 0.8, delta=3)
+
+    @responses.activate
+    def test_cookie_without_expiry(self):
+        self.cookie_expire_time = None
+        self.client.get_session_information()
+        self.assertEqual(responses.calls[-1].request.headers["Cookie"], "AuthSession=foobar")
+        self.cookie_value = "bar"
+        self.authenticator.token_manager.refresh_time = 0
+        self.client.get_session_information()
+        self.assertEqual(responses.calls[-1].request.headers["Cookie"], "AuthSession=bar")
+        token_manager = self.authenticator.token_manager
+        self.assertIsNotNone(token_manager.expire_time)
+        self.assertIsNotNone(token_manager.refresh_time)
+        self.assertFalse(token_manager._is_token_expired())
+        self.assertGreater(token_manager.expire_time, token_manager._get_current_time())
+
+    @responses.activate
     def test_set_service_url(self):
+        self.cookie_expire_time = None
         self.client.get_session_information()
         self.assertEqual(responses.calls[-2].request.url, "http://cloudant.example/_session")
         self.assertEqual(responses.calls[-2].request.method, "POST")


### PR DESCRIPTION
## PR summary

When using session cookies there is no `expires` or `max-age` attribute available. This raises a `TypeError` when we try to compare the `None` to the current time.

Fixes i1361

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
When authenticating with a session cookie, the AuthSession cookie has no `Expires` or `Max-Age` attribute. The requests library parses cookie.expires as `None` in this case. This raised a `TypeError` as soon as `ibm_cloud_sdk_core`'s TokenManager compared the `None` `expire_time` against the current time.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
It now falls back to a default TTL of 400 days when `cookie.expires` is `None`.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
Added a regression test that simulates a session cookie with no `Expires/Max-Age` attribute and verifies that authentication succeeds without error.